### PR TITLE
Allow words on line before target word

### DIFF
--- a/lib/alice/handlers/karma.ex
+++ b/lib/alice/handlers/karma.ex
@@ -5,9 +5,9 @@ defmodule Alice.Handlers.Karma do
 
   use Alice.Router
 
-  route   ~r/\A([^\s]+)\+\+(?:(?=\s)|$)/i, :increment
-  route   ~r/\A([^\s]+)--(?:(?=\s)|$)/i,   :decrement
-  route   ~r/\A([^\s]+)~~(?:(?=\s)|$)/i,   :check
+  route   ~r/\b([^\s]+)\+\+(?:(?=\s)|$)/i, :increment
+  route   ~r/\b([^\s]+)--(?:(?=\s)|$)/i,   :decrement
+  route   ~r/\b([^\s]+)~~(?:(?=\s)|$)/i,   :check
   command ~r/\bkarma\z/i,                  :best
   command ~r/\bkarma best( \d+)?\z/i,      :best
   command ~r/\bkarma worst( \d+)?\z/i,     :worst


### PR DESCRIPTION
Previously, the line had to begin with the target word, although there could be words after.

For instance, 

> I love tacos! 🌮++

would not fire, but

> 🌮++ because 🌮

would.

This change would allow both to work.
